### PR TITLE
Make InterpolateHandPoses follow the same logic as *HandIsValid

### DIFF
--- a/Source/CustomAvatar/PoseManager.cs
+++ b/Source/CustomAvatar/PoseManager.cs
@@ -201,9 +201,11 @@ namespace CustomAvatar
                 Pose openPose = (Pose)field.GetValue(this);
                 Pose closedPose = (Pose)closed.GetValue(this);
 
+                Transform boneTransform = animator.GetBoneTransform(bone);
+		
+                if (!boneTransform) continue;
                 if (openPose.Equals(Pose.identity) || closedPose.Equals(Pose.identity)) return;
 
-                Transform boneTransform = animator.GetBoneTransform(bone);
                 boneTransform.localPosition = Vector3.Lerp(openPose.position, closedPose.position, t);
                 boneTransform.localRotation = Quaternion.Slerp(openPose.rotation, closedPose.rotation, t);
             }


### PR DESCRIPTION
This fixes pose interpolation in the editor for some avatars (read: those with less than 5 fingers or less than 3 bones per finger) so that all transformations are applied, instead of bailing out at the first missing bone.

This will still bail out at the first present bone with no transform applied.