### PR TITLE
Fixed mutliple bugs and BeatLeader compatibility.

### DIFF
--- a/Source/CustomAvatar/Player/GameEnvironmentObjectManager.cs
+++ b/Source/CustomAvatar/Player/GameEnvironmentObjectManager.cs
@@ -128,13 +128,13 @@ namespace CustomAvatar.Player
 
             var controller = (Component)_container.TryResolve(BeatLeaderReflection.kCameraControllerType);
             var originComponent = (Component)_container.TryResolve(BeatLeaderReflection.kOriginComponentType);
-            var camera = BeatLeaderReflection.kCameraField(controller);
+            Camera camera = BeatLeaderReflection.kCameraField(controller);
 
             if (controller == null || originComponent == null || camera == null)
             {
                 return;
             }
-            
+
             SpectatorCamera spectatorCameraController = _container.InstantiateComponent<SpectatorCamera>(camera.gameObject);
             spectatorCameraController.origin = BeatLeaderReflection.kReplayerCoreGetter(originComponent);
             spectatorCameraController.playerSpace = BeatLeaderReflection.kReplayerCenterAdjustGetter(originComponent);

--- a/Source/CustomAvatar/Player/GameEnvironmentObjectManager.cs
+++ b/Source/CustomAvatar/Player/GameEnvironmentObjectManager.cs
@@ -128,13 +128,14 @@ namespace CustomAvatar.Player
 
             var controller = (Component)_container.TryResolve(BeatLeaderReflection.kCameraControllerType);
             var originComponent = (Component)_container.TryResolve(BeatLeaderReflection.kOriginComponentType);
+            var camera = BeatLeaderReflection.kCameraField(controller);
 
-            if (controller == null || originComponent == null)
+            if (controller == null || originComponent == null || camera == null)
             {
                 return;
             }
-
-            SpectatorCamera spectatorCameraController = _container.InstantiateComponent<SpectatorCamera>(BeatLeaderReflection.kCameraField(controller).gameObject);
+            
+            SpectatorCamera spectatorCameraController = _container.InstantiateComponent<SpectatorCamera>(camera.gameObject);
             spectatorCameraController.origin = BeatLeaderReflection.kReplayerCoreGetter(originComponent);
             spectatorCameraController.playerSpace = BeatLeaderReflection.kReplayerCenterAdjustGetter(originComponent);
         }

--- a/Source/CustomAvatar/Rendering/MainCamera.cs
+++ b/Source/CustomAvatar/Rendering/MainCamera.cs
@@ -154,11 +154,13 @@ namespace CustomAvatar.Rendering
 
         private void OnFocusChanged(bool hasFocus)
         {
-            _trackedPoseDriver.UseRelativeTransform = !hasFocus;
-            _trackedPoseDriver.originPose = hasFocus ? Pose.identity : new Pose(
-                Vector3.Project(Quaternion.Euler(0, 180, 0) * -transform.localPosition * 2, Vector3.right) + new Vector3(0, 0, 1.5f),
-                Quaternion.Euler(0, 180, 0));
-
+            if (_trackedPoseDriver != null)
+            {
+                _trackedPoseDriver.UseRelativeTransform = !hasFocus;
+                _trackedPoseDriver.originPose = hasFocus ? Pose.identity : new Pose(
+                    Vector3.Project(Quaternion.Euler(0, 180, 0) * -transform.localPosition * 2, Vector3.right) + new Vector3(0, 0, 1.5f),
+                    Quaternion.Euler(0, 180, 0));
+            }
             UpdateCameraMask();
         }
 

--- a/Source/CustomAvatar/Rendering/MainCamera.cs
+++ b/Source/CustomAvatar/Rendering/MainCamera.cs
@@ -163,6 +163,7 @@ namespace CustomAvatar.Rendering
                     Vector3.Project(Quaternion.Euler(0, 180, 0) * -transform.localPosition * 2, Vector3.right) + new Vector3(0, 0, 1.5f),
                     Quaternion.Euler(0, 180, 0));
             }
+
             UpdateCameraMask();
         }
 

--- a/Source/CustomAvatar/Rendering/MainCamera.cs
+++ b/Source/CustomAvatar/Rendering/MainCamera.cs
@@ -68,16 +68,19 @@ namespace CustomAvatar.Rendering
         {
             if (_settings != null)
             {
+                _settings.cameraNearClipPlane.changed -= OnCameraNearClipPlaneChanged;
                 _settings.cameraNearClipPlane.changed += OnCameraNearClipPlaneChanged;
             }
 
             if (_fpfcSettings != null)
             {
+                _fpfcSettings.Changed -= OnFpfcSettingsChanged;
                 _fpfcSettings.Changed += OnFpfcSettingsChanged;
             }
 
             if (_beatSaberUtilities != null)
             {
+                _beatSaberUtilities.focusChanged -= OnFocusChanged;
                 _beatSaberUtilities.focusChanged += OnFocusChanged;
                 OnFocusChanged(_beatSaberUtilities.hasFocus);
             }
@@ -138,7 +141,6 @@ namespace CustomAvatar.Rendering
 
         private void OnDestroy()
         {
-            OnDisable();
             RemoveFromPlayerSpaceManager();
         }
 

--- a/Source/CustomAvatar/Rendering/MainCamera.cs
+++ b/Source/CustomAvatar/Rendering/MainCamera.cs
@@ -138,6 +138,7 @@ namespace CustomAvatar.Rendering
 
         private void OnDestroy()
         {
+            OnDisable();
             RemoveFromPlayerSpaceManager();
         }
 


### PR DESCRIPTION
This PR
- Fixes a problem of camera being subscribed to events even after destroy. The problem usually been happening in multiplayer.
- Fixes compatibility with BeatLeader in FPFC mode with Camera2 (when replayer camera is not available).
- Fixes compatibility with BeatLeader in just FPFC mode (when TrackedPoseDriver does not exist).