### PR TITLE
handle tracker being null in FixTrackingReference

### DIFF
--- a/Source/CustomAvatar/Avatar/AvatarPrefab.cs
+++ b/Source/CustomAvatar/Avatar/AvatarPrefab.cs
@@ -310,6 +310,12 @@ namespace CustomAvatar.Avatar
                 return;
             }
 
+            if (!tracker)
+            {
+                _logger.LogWarning($"Could not find tracker transform for {name} reference");
+                return;
+            }
+
             Vector3 offset = target.position - reference.position;
 
             // only warn if offset is larger than 1 mm


### PR DESCRIPTION
prevents nullreferenceexceptions from being thrown and breaking the entire avatar loading process with no useful debugging output